### PR TITLE
🔥 Remove isort configuration, since we use Ruff now

### DIFF
--- a/backend/app/tests/api/routes/test_login.py
+++ b/backend/app/tests/api/routes/test_login.py
@@ -42,8 +42,9 @@ def test_use_access_token(
 def test_recovery_password(
     client: TestClient, normal_user_token_headers: dict[str, str]
 ) -> None:
-    with patch("app.core.config.settings.SMTP_HOST", "smtp.example.com"), patch(
-        "app.core.config.settings.SMTP_USER", "admin@example.com"
+    with (
+        patch("app.core.config.settings.SMTP_HOST", "smtp.example.com"),
+        patch("app.core.config.settings.SMTP_USER", "admin@example.com"),
     ):
         email = "test@example.com"
         r = client.post(

--- a/backend/app/tests/api/routes/test_users.py
+++ b/backend/app/tests/api/routes/test_users.py
@@ -34,9 +34,11 @@ def test_get_users_normal_user_me(
 def test_create_user_new_email(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    with patch("app.utils.send_email", return_value=None), patch(
-        "app.core.config.settings.SMTP_HOST", "smtp.example.com"
-    ), patch("app.core.config.settings.SMTP_USER", "admin@example.com"):
+    with (
+        patch("app.utils.send_email", return_value=None),
+        patch("app.core.config.settings.SMTP_HOST", "smtp.example.com"),
+        patch("app.core.config.settings.SMTP_USER", "admin@example.com"),
+    ):
         username = random_email()
         password = random_lower_string()
         data = {"email": username, "password": password}

--- a/backend/app/tests/scripts/test_backend_pre_start.py
+++ b/backend/app/tests/scripts/test_backend_pre_start.py
@@ -12,9 +12,12 @@ def test_init_successful_connection() -> None:
     exec_mock = MagicMock(return_value=True)
     session_mock.configure_mock(**{"exec.return_value": exec_mock})
 
-    with patch("sqlmodel.Session", return_value=session_mock), patch.object(
-        logger, "info"
-    ), patch.object(logger, "error"), patch.object(logger, "warn"):
+    with (
+        patch("sqlmodel.Session", return_value=session_mock),
+        patch.object(logger, "info"),
+        patch.object(logger, "error"),
+        patch.object(logger, "warn"),
+    ):
         try:
             init(engine_mock)
             connection_successful = True

--- a/backend/app/tests/scripts/test_test_pre_start.py
+++ b/backend/app/tests/scripts/test_test_pre_start.py
@@ -12,9 +12,12 @@ def test_init_successful_connection() -> None:
     exec_mock = MagicMock(return_value=True)
     session_mock.configure_mock(**{"exec.return_value": exec_mock})
 
-    with patch("sqlmodel.Session", return_value=session_mock), patch.object(
-        logger, "info"
-    ), patch.object(logger, "error"), patch.object(logger, "warn"):
+    with (
+        patch("sqlmodel.Session", return_value=session_mock),
+        patch.object(logger, "info"),
+        patch.object(logger, "error"),
+        patch.object(logger, "warn"),
+    ):
         try:
             init(engine_mock)
             connection_successful = True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,11 +36,6 @@ types-python-jose = "^3.3.4.20240106"
 types-passlib = "^1.7.7.20240106"
 coverage = "^7.4.3"
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-line_length = 88
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/backend/scripts/format-imports.sh
+++ b/backend/scripts/format-imports.sh
@@ -1,6 +1,0 @@
-#!/bin/sh -e
-set -x
-
-# Sort imports one per line, so autoflake can remove unused imports
-isort --recursive  --force-single-line-imports --apply app
-sh ./scripts/format.sh

--- a/backend/scripts/format.sh
+++ b/backend/scripts/format.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+set -x
+
+ruff check app scripts --fix
+ruff format app scripts

--- a/backend/scripts/format.sh
+++ b/backend/scripts/format.sh
@@ -1,6 +1,4 @@
 #!/bin/sh -e
 set -x
 
-autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place app --exclude=__init__.py
-black app
-isort --recursive --apply app
+ruff format

--- a/backend/scripts/format.sh
+++ b/backend/scripts/format.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -e
-set -x
-
-ruff format

--- a/backend/scripts/lint.sh
+++ b/backend/scripts/lint.sh
@@ -4,5 +4,5 @@ set -e
 set -x
 
 mypy app
-ruff app
+ruff check app
 ruff format app --check


### PR DESCRIPTION
This PR removes the isort configuration from pyproject.toml

The configuration options we had set aren't supported by ruff just yet,
but I think the default config is pretty much what we want (after all
running ruff now didn't change anything).

I'm also removing the calls to isort, since we want to use ruff for this.

I've also update the `format.sh` script to use ruff, do we want to keep it?
