### PR TITLE
Fix: reset password

### DIFF
--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -83,7 +83,7 @@ def reset_password(session: SessionDep, body: NewPassword) -> Message:
     user_id = verify_password_reset_token(token=body.token)
     if not user_id:
         raise HTTPException(status_code=400, detail="Invalid token")
-    user = session.get(User, user_id)
+    user = session.get(User, int(user_id))
     if not user:
         raise HTTPException(
             status_code=404,

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -38,7 +38,7 @@ def login_access_token(
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     return Token(
         access_token=security.create_access_token(
-            user.id, expires_delta=access_token_expires
+            user.email, expires_delta=access_token_expires
         )
     )
 


### PR DESCRIPTION
In the current implementation, the verify_password_reset_token function is used to extract the email from the token. This function is designed to return the email that was used to generate the token. However, if the token was generated using the user's ID instead of their email, this function will return the user's ID, not their email.

This is problematic because the rest of the /reset-password route expects to work with the user's email, not their ID. The get_user_by_email function is used to look up the user in the database, and this function expects an email as input. If it receives a user ID instead, it will not be able to find the user, and the password reset will fail.

Therefore, in order for the password reset to work, the token needs to be generated using the user's email, not their ID. This will ensure that the verify_password_reset_token function returns the correct email, and that the get_user_by_email function can successfully find the user in the database.