### PR TITLE
🥅 Handle AxiosErrors in Login page

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { AxiosError } from "axios"
 import {
   type Body_login_login_access_token as AccessToken,
   type ApiError,
@@ -9,7 +10,6 @@ import {
   type UserPublic,
   UsersService,
 } from "../client"
-import { AxiosError } from "axios"
 
 const isLoggedIn = () => {
   return localStorage.getItem("access_token") !== null

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -9,6 +9,7 @@ import {
   type UserPublic,
   UsersService,
 } from "../client"
+import { AxiosError } from "axios"
 
 const isLoggedIn = () => {
   return localStorage.getItem("access_token") !== null
@@ -36,7 +37,12 @@ const useAuth = () => {
       navigate({ to: "/" })
     },
     onError: (err: ApiError) => {
-      const errDetail = (err.body as any)?.detail
+      let errDetail = (err.body as any)?.detail
+
+      if (err instanceof AxiosError) {
+        errDetail = err.message
+      }
+
       setError(errDetail)
     },
   })


### PR DESCRIPTION
Tiny PR to check for (mostly) network errors, it shows like this:

![CleanShot 2024-04-09 at 15 38 45](https://github.com/tiangolo/full-stack-fastapi-template/assets/667029/1d9d4638-b443-4f21-bfc0-843572fc04a9)

This happens when the user is not connected to the network or when the backend is down