### PR TITLE
♻️ Fix tests when first superuser password is changed in .env

### DIFF
--- a/backend/app/tests/api/routes/test_login.py
+++ b/backend/app/tests/api/routes/test_login.py
@@ -70,7 +70,7 @@ def test_reset_password(
     client: TestClient, superuser_token_headers: dict[str, str]
 ) -> None:
     token = generate_password_reset_token(email=settings.FIRST_SUPERUSER)
-    data = {"new_password": "changethis", "token": token}
+    data = {"new_password": settings.FIRST_SUPERUSER_PASSWORD, "token": token}
     r = client.post(
         f"{settings.API_V1_STR}/reset-password/",
         headers=superuser_token_headers,


### PR DESCRIPTION
The `test_reset_password` test changes user password. It will break other tests becuase `get_superuser_token_headers` function won't able to get access_token.

It relates to #217 