### PR TITLE
Mark login field as required

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -43,6 +43,10 @@ const useAuth = () => {
         errDetail = err.message
       }
 
+      if (Array.isArray(errDetail)) {
+        errDetail = "Something went wrong"
+      }
+
       setError(errDetail)
     },
   })

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -92,6 +92,7 @@ function Login() {
             })}
             placeholder="Email"
             type="email"
+            required
           />
           {errors.username && (
             <FormErrorMessage>{errors.username.message}</FormErrorMessage>
@@ -103,6 +104,7 @@ function Login() {
               {...register("password")}
               type={show ? "text" : "password"}
               placeholder="Password"
+              required
             />
             <InputRightElement
               color="ui.dim"


### PR DESCRIPTION
This PR marks email and password as required, so we don't send
the form if they are empty.

It also checks if errors returned by the server are a list, and, if so,
we show a generic error message.
