### PR TITLE
🐛 Fix local Traefik proxy network config to fix Gateway Timeouts

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -36,6 +36,9 @@ services:
       # Dummy https-redirect middleware that doesn't really redirect, only to
       # allow running it locally
       - traefik.http.middlewares.https-redirect.contenttype.autodetect=false
+    networks:
+      - traefik-public
+      - default
 
   db:
     restart: "no"


### PR DESCRIPTION
The network config of the proxy service for the local docker setup (docker-compose.override.yaml) is missing and therefore the proxy service can't reach the backend service (produces Gateway Timeouts).

See https://github.com/tiangolo/full-stack-fastapi-template/discussions/1183