### PR TITLE
✨ Enable Traefik to use SSL when having Cloudflare as DNS Provider

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -87,6 +87,13 @@ export DOMAIN=fastapi-project.example.com
 export EMAIL=admin@example.com
 ```
 
+* If you use CloudFlare as DNS provider you have to set your CloudFlare Account Email and the Global API Key from Cloudflare
+
+```bash
+export CF_API_EMAIL=admin@example.com
+export CF_API_KEY=yourcloudflareglobalapikey
+```
+
 **Note**: you need to set a different email, an email `@example.com` won't work.
 
 ### Start the Traefik Docker Compose

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -40,6 +40,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # Mount the volume to store the certificates
       - traefik-public-certificates:/certificates
+    environment:
+      - "CF_API_EMAIL=${CF_API_EMAIL?Variable not set}"
+      - "CF_API_KEY=${CF_API_KEY?Variable not set}"
     command:
       # Enable Docker in Traefik, so that it reads labels from Docker services
       - --providers.docker


### PR DESCRIPTION
This PR will enable Traefik to also support HTTPS when the Domain is managed by Cloudflare. If the Enviroment Variable is not set it will work on any other DNS Provider.

Updated Deployment.md also to clarify how to use it,