### PR TITLE
Updated README with grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     - 🦇 Dark mode support.
 - 🐋 [Docker Compose](https://www.docker.com) for development and production.
 - 🔒 Secure password hashing by default.
-- 🔑 JWT token authentication.
+- 🔑 JWT authentication.
 - 📫 Email based password recovery.
 - ✅ Tests with [Pytest](https://pytest.org).
 - 📞 [Traefik](https://traefik.io) as a reverse proxy / load balancer.


### PR DESCRIPTION
Fixed a spelling issue where JWT token (JSON web token token) was written, instead of just JWT