### PR TITLE
🐛 Fix welcome page to show logged-in user

### DIFF
--- a/frontend/src/routes/_layout/index.tsx
+++ b/frontend/src/routes/_layout/index.tsx
@@ -1,17 +1,14 @@
 import { Box, Container, Text } from "@chakra-ui/react"
-import { useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 
-import type { UserPublic } from "../../client"
+import useAuth from "../../hooks/useAuth"
 
 export const Route = createFileRoute("/_layout/")({
   component: Dashboard,
 })
 
 function Dashboard() {
-  const queryClient = useQueryClient()
-
-  const currentUser = queryClient.getQueryData<UserPublic>(["currentUser"])
+  const { user: currentUser } = useAuth()
 
   return (
     <>


### PR DESCRIPTION
Use up-to-date logged-in user value from `useAuth`, instead of stale query data.
`useAuth` correctly refreshes, and holds the up-to-date value of the currently logged-in user.

This is fixing the following issue:
1. User A is logged in, welcome screen is correct (Hi, A 👋🏼)
2. User A logs off
3. User B logs in, welcome screen is wrongly still showing A's welcome screen (Hi, A 👋🏼)
4. Refresh the page, and welcome screen is showing correctly (Hi, B 👋🏼)