### PR TITLE
Regenerate OpenAPI's client code

### DIFF
--- a/frontend/src/client/services.ts
+++ b/frontend/src/client/services.ts
@@ -4,19 +4,19 @@ import { request as __request } from './core/request';
 
 import type { Body_login_login_access_token,Message,NewPassword,Token,UserPublic,UpdatePassword,UserCreate,UserRegister,UsersPublic,UserUpdate,UserUpdateMe,ItemCreate,ItemPublic,ItemsPublic,ItemUpdate } from './models';
 
-export type TDataLoginAccessToken = {
+export type TDataLoginLoginAccessToken = {
                 formData: Body_login_login_access_token
                 
             }
-export type TDataRecoverPassword = {
+export type TDataLoginRecoverPassword = {
                 email: string
                 
             }
-export type TDataResetPassword = {
+export type TDataLoginResetPassword = {
                 requestBody: NewPassword
                 
             }
-export type TDataRecoverPasswordHtmlContent = {
+export type TDataLoginRecoverPasswordHtmlContent = {
                 email: string
                 
             }
@@ -29,7 +29,7 @@ export class LoginService {
 	 * @returns Token Successful Response
 	 * @throws ApiError
 	 */
-	public static loginAccessToken(data: TDataLoginAccessToken): CancelablePromise<Token> {
+	public static loginLoginAccessToken(data: TDataLoginLoginAccessToken): CancelablePromise<Token> {
 		const {
 formData,
 } = data;
@@ -50,7 +50,7 @@ formData,
 	 * @returns UserPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static testToken(): CancelablePromise<UserPublic> {
+	public static loginTestToken(): CancelablePromise<UserPublic> {
 				return __request(OpenAPI, {
 			method: 'POST',
 			url: '/api/v1/login/test-token',
@@ -63,7 +63,7 @@ formData,
 	 * @returns Message Successful Response
 	 * @throws ApiError
 	 */
-	public static recoverPassword(data: TDataRecoverPassword): CancelablePromise<Message> {
+	public static loginRecoverPassword(data: TDataLoginRecoverPassword): CancelablePromise<Message> {
 		const {
 email,
 } = data;
@@ -85,7 +85,7 @@ email,
 	 * @returns Message Successful Response
 	 * @throws ApiError
 	 */
-	public static resetPassword(data: TDataResetPassword): CancelablePromise<Message> {
+	public static loginResetPassword(data: TDataLoginResetPassword): CancelablePromise<Message> {
 		const {
 requestBody,
 } = data;
@@ -106,7 +106,7 @@ requestBody,
 	 * @returns string Successful Response
 	 * @throws ApiError
 	 */
-	public static recoverPasswordHtmlContent(data: TDataRecoverPasswordHtmlContent): CancelablePromise<string> {
+	public static loginRecoverPasswordHtmlContent(data: TDataLoginRecoverPasswordHtmlContent): CancelablePromise<string> {
 		const {
 email,
 } = data;
@@ -124,37 +124,37 @@ email,
 
 }
 
-export type TDataReadUsers = {
+export type TDataUsersReadUsers = {
                 limit?: number
 skip?: number
                 
             }
-export type TDataCreateUser = {
+export type TDataUsersCreateUser = {
                 requestBody: UserCreate
                 
             }
-export type TDataUpdateUserMe = {
+export type TDataUsersUpdateUserMe = {
                 requestBody: UserUpdateMe
                 
             }
-export type TDataUpdatePasswordMe = {
+export type TDataUsersUpdatePasswordMe = {
                 requestBody: UpdatePassword
                 
             }
-export type TDataRegisterUser = {
+export type TDataUsersRegisterUser = {
                 requestBody: UserRegister
                 
             }
-export type TDataReadUserById = {
+export type TDataUsersReadUserById = {
                 userId: number
                 
             }
-export type TDataUpdateUser = {
+export type TDataUsersUpdateUser = {
                 requestBody: UserUpdate
 userId: number
                 
             }
-export type TDataDeleteUser = {
+export type TDataUsersDeleteUser = {
                 userId: number
                 
             }
@@ -167,7 +167,7 @@ export class UsersService {
 	 * @returns UsersPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static readUsers(data: TDataReadUsers = {}): CancelablePromise<UsersPublic> {
+	public static usersReadUsers(data: TDataUsersReadUsers = {}): CancelablePromise<UsersPublic> {
 		const {
 limit = 100,
 skip = 0,
@@ -190,7 +190,7 @@ skip = 0,
 	 * @returns UserPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static createUser(data: TDataCreateUser): CancelablePromise<UserPublic> {
+	public static usersCreateUser(data: TDataUsersCreateUser): CancelablePromise<UserPublic> {
 		const {
 requestBody,
 } = data;
@@ -211,9 +211,22 @@ requestBody,
 	 * @returns UserPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static readUserMe(): CancelablePromise<UserPublic> {
+	public static usersReadUserMe(): CancelablePromise<UserPublic> {
 				return __request(OpenAPI, {
 			method: 'GET',
+			url: '/api/v1/users/me',
+		});
+	}
+
+	/**
+	 * Delete User Me
+	 * Delete own user.
+	 * @returns Message Successful Response
+	 * @throws ApiError
+	 */
+	public static usersDeleteUserMe(): CancelablePromise<Message> {
+				return __request(OpenAPI, {
+			method: 'DELETE',
 			url: '/api/v1/users/me',
 		});
 	}
@@ -224,7 +237,7 @@ requestBody,
 	 * @returns UserPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static updateUserMe(data: TDataUpdateUserMe): CancelablePromise<UserPublic> {
+	public static usersUpdateUserMe(data: TDataUsersUpdateUserMe): CancelablePromise<UserPublic> {
 		const {
 requestBody,
 } = data;
@@ -245,7 +258,7 @@ requestBody,
 	 * @returns Message Successful Response
 	 * @throws ApiError
 	 */
-	public static updatePasswordMe(data: TDataUpdatePasswordMe): CancelablePromise<Message> {
+	public static usersUpdatePasswordMe(data: TDataUsersUpdatePasswordMe): CancelablePromise<Message> {
 		const {
 requestBody,
 } = data;
@@ -266,7 +279,7 @@ requestBody,
 	 * @returns UserPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static registerUser(data: TDataRegisterUser): CancelablePromise<UserPublic> {
+	public static usersRegisterUser(data: TDataUsersRegisterUser): CancelablePromise<UserPublic> {
 		const {
 requestBody,
 } = data;
@@ -287,7 +300,7 @@ requestBody,
 	 * @returns UserPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static readUserById(data: TDataReadUserById): CancelablePromise<UserPublic> {
+	public static usersReadUserById(data: TDataUsersReadUserById): CancelablePromise<UserPublic> {
 		const {
 userId,
 } = data;
@@ -309,7 +322,7 @@ userId,
 	 * @returns UserPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static updateUser(data: TDataUpdateUser): CancelablePromise<UserPublic> {
+	public static usersUpdateUser(data: TDataUsersUpdateUser): CancelablePromise<UserPublic> {
 		const {
 requestBody,
 userId,
@@ -334,7 +347,7 @@ userId,
 	 * @returns Message Successful Response
 	 * @throws ApiError
 	 */
-	public static deleteUser(data: TDataDeleteUser): CancelablePromise<Message> {
+	public static usersDeleteUser(data: TDataUsersDeleteUser): CancelablePromise<Message> {
 		const {
 userId,
 } = data;
@@ -352,7 +365,7 @@ userId,
 
 }
 
-export type TDataTestEmail = {
+export type TDataUtilsTestEmail = {
                 emailTo: string
                 
             }
@@ -365,7 +378,7 @@ export class UtilsService {
 	 * @returns Message Successful Response
 	 * @throws ApiError
 	 */
-	public static testEmail(data: TDataTestEmail): CancelablePromise<Message> {
+	public static utilsTestEmail(data: TDataUtilsTestEmail): CancelablePromise<Message> {
 		const {
 emailTo,
 } = data;
@@ -383,25 +396,25 @@ emailTo,
 
 }
 
-export type TDataReadItems = {
+export type TDataItemsReadItems = {
                 limit?: number
 skip?: number
                 
             }
-export type TDataCreateItem = {
+export type TDataItemsCreateItem = {
                 requestBody: ItemCreate
                 
             }
-export type TDataReadItem = {
+export type TDataItemsReadItem = {
                 id: number
                 
             }
-export type TDataUpdateItem = {
+export type TDataItemsUpdateItem = {
                 id: number
 requestBody: ItemUpdate
                 
             }
-export type TDataDeleteItem = {
+export type TDataItemsDeleteItem = {
                 id: number
                 
             }
@@ -414,7 +427,7 @@ export class ItemsService {
 	 * @returns ItemsPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static readItems(data: TDataReadItems = {}): CancelablePromise<ItemsPublic> {
+	public static itemsReadItems(data: TDataItemsReadItems = {}): CancelablePromise<ItemsPublic> {
 		const {
 limit = 100,
 skip = 0,
@@ -437,7 +450,7 @@ skip = 0,
 	 * @returns ItemPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static createItem(data: TDataCreateItem): CancelablePromise<ItemPublic> {
+	public static itemsCreateItem(data: TDataItemsCreateItem): CancelablePromise<ItemPublic> {
 		const {
 requestBody,
 } = data;
@@ -458,7 +471,7 @@ requestBody,
 	 * @returns ItemPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static readItem(data: TDataReadItem): CancelablePromise<ItemPublic> {
+	public static itemsReadItem(data: TDataItemsReadItem): CancelablePromise<ItemPublic> {
 		const {
 id,
 } = data;
@@ -480,7 +493,7 @@ id,
 	 * @returns ItemPublic Successful Response
 	 * @throws ApiError
 	 */
-	public static updateItem(data: TDataUpdateItem): CancelablePromise<ItemPublic> {
+	public static itemsUpdateItem(data: TDataItemsUpdateItem): CancelablePromise<ItemPublic> {
 		const {
 id,
 requestBody,
@@ -505,7 +518,7 @@ requestBody,
 	 * @returns Message Successful Response
 	 * @throws ApiError
 	 */
-	public static deleteItem(data: TDataDeleteItem): CancelablePromise<Message> {
+	public static itemsDeleteItem(data: TDataItemsDeleteItem): CancelablePromise<Message> {
 		const {
 id,
 } = data;

--- a/frontend/src/components/Admin/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser.tsx
@@ -55,7 +55,7 @@ const AddUser = ({ isOpen, onClose }: AddUserProps) => {
 
   const mutation = useMutation({
     mutationFn: (data: UserCreate) =>
-      UsersService.createUser({ requestBody: data }),
+      UsersService.usersCreateUser({ requestBody: data }),
     onSuccess: () => {
       showToast("Success!", "User created successfully.", "success")
       reset()

--- a/frontend/src/components/Admin/EditUser.tsx
+++ b/frontend/src/components/Admin/EditUser.tsx
@@ -54,7 +54,7 @@ const EditUser = ({ user, isOpen, onClose }: EditUserProps) => {
 
   const mutation = useMutation({
     mutationFn: (data: UserUpdateForm) =>
-      UsersService.updateUser({ userId: user.id, requestBody: data }),
+      UsersService.usersUpdateUser({ userId: user.id, requestBody: data }),
     onSuccess: () => {
       showToast("Success!", "User updated successfully.", "success")
       onClose()

--- a/frontend/src/components/Common/DeleteAlert.tsx
+++ b/frontend/src/components/Common/DeleteAlert.tsx
@@ -32,9 +32,9 @@ const Delete = ({ type, id, isOpen, onClose }: DeleteProps) => {
 
   const deleteEntity = async (id: number) => {
     if (type === "Item") {
-      await ItemsService.deleteItem({ id: id })
+      await ItemsService.itemsDeleteItem({ id: id })
     } else if (type === "User") {
-      await UsersService.deleteUser({ userId: id })
+      await UsersService.usersDeleteUser({ userId: id })
     } else {
       throw new Error(`Unexpected type: ${type}`)
     }

--- a/frontend/src/components/Items/AddItem.tsx
+++ b/frontend/src/components/Items/AddItem.tsx
@@ -42,7 +42,7 @@ const AddItem = ({ isOpen, onClose }: AddItemProps) => {
 
   const mutation = useMutation({
     mutationFn: (data: ItemCreate) =>
-      ItemsService.createItem({ requestBody: data }),
+      ItemsService.itemsCreateItem({ requestBody: data }),
     onSuccess: () => {
       showToast("Success!", "Item created successfully.", "success")
       reset()

--- a/frontend/src/components/Items/EditItem.tsx
+++ b/frontend/src/components/Items/EditItem.tsx
@@ -45,7 +45,7 @@ const EditItem = ({ item, isOpen, onClose }: EditItemProps) => {
 
   const mutation = useMutation({
     mutationFn: (data: ItemUpdate) =>
-      ItemsService.updateItem({ id: item.id, requestBody: data }),
+      ItemsService.itemsUpdateItem({ id: item.id, requestBody: data }),
     onSuccess: () => {
       showToast("Success!", "Item updated successfully.", "success")
       onClose()

--- a/frontend/src/components/UserSettings/ChangePassword.tsx
+++ b/frontend/src/components/UserSettings/ChangePassword.tsx
@@ -36,7 +36,7 @@ const ChangePassword = () => {
 
   const mutation = useMutation({
     mutationFn: (data: UpdatePassword) =>
-      UsersService.updatePasswordMe({ requestBody: data }),
+      UsersService.usersUpdatePasswordMe({ requestBody: data }),
     onSuccess: () => {
       showToast("Success!", "Password updated.", "success")
       reset()

--- a/frontend/src/components/UserSettings/DeleteConfirmation.tsx
+++ b/frontend/src/components/UserSettings/DeleteConfirmation.tsx
@@ -32,7 +32,7 @@ const DeleteConfirmation = ({ isOpen, onClose }: DeleteProps) => {
   const { logout } = useAuth()
 
   const mutation = useMutation({
-    mutationFn: (id: number) => UsersService.deleteUser({ userId: id }),
+    mutationFn: (id: number) => UsersService.usersDeleteUser({ userId: id }),
     onSuccess: () => {
       showToast(
         "Success",

--- a/frontend/src/components/UserSettings/UserInformation.tsx
+++ b/frontend/src/components/UserSettings/UserInformation.tsx
@@ -52,7 +52,7 @@ const UserInformation = () => {
 
   const mutation = useMutation({
     mutationFn: (data: UserUpdateMe) =>
-      UsersService.updateUserMe({ requestBody: data }),
+      UsersService.usersUpdateUserMe({ requestBody: data }),
     onSuccess: () => {
       showToast("Success!", "User updated successfully.", "success")
     },

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -20,12 +20,12 @@ const useAuth = () => {
   const navigate = useNavigate()
   const { data: user, isLoading } = useQuery<UserPublic | null, Error>({
     queryKey: ["currentUser"],
-    queryFn: UsersService.readUserMe,
+    queryFn: UsersService.usersReadUserMe,
     enabled: isLoggedIn(),
   })
 
   const login = async (data: AccessToken) => {
-    const response = await LoginService.loginAccessToken({
+    const response = await LoginService.loginLoginAccessToken({
       formData: data,
     })
     localStorage.setItem("access_token", response.access_token)

--- a/frontend/src/routes/_layout/admin.tsx
+++ b/frontend/src/routes/_layout/admin.tsx
@@ -31,7 +31,7 @@ const MembersTableBody = () => {
 
   const { data: users } = useSuspenseQuery({
     queryKey: ["users"],
-    queryFn: () => UsersService.readUsers({}),
+    queryFn: () => UsersService.usersReadUsers({}),
   })
 
   return (

--- a/frontend/src/routes/_layout/items.tsx
+++ b/frontend/src/routes/_layout/items.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute("/_layout/items")({
 function ItemsTableBody() {
   const { data: items } = useSuspenseQuery({
     queryKey: ["items"],
-    queryFn: () => ItemsService.readItems({}),
+    queryFn: () => ItemsService.itemsReadItems({}),
   })
 
   return (

--- a/frontend/src/routes/recover-password.tsx
+++ b/frontend/src/routes/recover-password.tsx
@@ -39,7 +39,7 @@ function RecoverPassword() {
   const showToast = useCustomToast()
 
   const onSubmit: SubmitHandler<FormData> = async (data) => {
-    await LoginService.recoverPassword({
+    await LoginService.loginRecoverPassword({
       email: data.email,
     })
     showToast(

--- a/frontend/src/routes/reset-password.tsx
+++ b/frontend/src/routes/reset-password.tsx
@@ -52,7 +52,7 @@ function ResetPassword() {
   const resetPassword = async (data: NewPassword) => {
     const token = new URLSearchParams(window.location.search).get("token")
     if (!token) return
-    await LoginService.resetPassword({
+    await LoginService.loginResetPassword({
       requestBody: { new_password: data.new_password, token: token },
     })
   }


### PR DESCRIPTION
It looks like the frontend's auto-generated client code is stale, following some changes like #1179.
I ran `npm run generate-client`, and this is the result.