### PR TITLE
🎨 Run biome after OpenAPI client generation

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -4,7 +4,7 @@
     "enabled": true
   },
   "files": {
-    "ignore": ["node_modules", "src/client/", "src/routeTree.gen.ts"]
+    "ignore": ["node_modules", "src/routeTree.gen.ts"]
   },
   "linter": {
     "enabled": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "lint": "biome check --apply-unsafe --no-errors-on-unmatched --files-ignore-unknown=true ./",
     "preview": "vite preview",
-    "generate-client": "openapi-ts --input ./openapi.json --output ./src/client --client axios --exportSchemas true"
+    "generate-client": "openapi-ts --input ./openapi.json --output ./src/client --client axios --exportSchemas true && biome format --write ./src/client"
   },
   "dependencies": {
     "@chakra-ui/icons": "2.1.1",

--- a/frontend/src/client/core/ApiError.ts
+++ b/frontend/src/client/core/ApiError.ts
@@ -1,21 +1,25 @@
-import type { ApiRequestOptions } from './ApiRequestOptions';
-import type { ApiResult } from './ApiResult';
+import type { ApiRequestOptions } from "./ApiRequestOptions"
+import type { ApiResult } from "./ApiResult"
 
 export class ApiError extends Error {
-	public readonly url: string;
-	public readonly status: number;
-	public readonly statusText: string;
-	public readonly body: unknown;
-	public readonly request: ApiRequestOptions;
+  public readonly url: string
+  public readonly status: number
+  public readonly statusText: string
+  public readonly body: unknown
+  public readonly request: ApiRequestOptions
 
-	constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
-		super(message);
+  constructor(
+    request: ApiRequestOptions,
+    response: ApiResult,
+    message: string,
+  ) {
+    super(message)
 
-		this.name = 'ApiError';
-		this.url = response.url;
-		this.status = response.status;
-		this.statusText = response.statusText;
-		this.body = response.body;
-		this.request = request;
-	}
+    this.name = "ApiError"
+    this.url = response.url
+    this.status = response.status
+    this.statusText = response.statusText
+    this.body = response.body
+    this.request = request
+  }
 }

--- a/frontend/src/client/core/ApiRequestOptions.ts
+++ b/frontend/src/client/core/ApiRequestOptions.ts
@@ -1,13 +1,20 @@
 export type ApiRequestOptions = {
-	readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
-	readonly url: string;
-	readonly path?: Record<string, unknown>;
-	readonly cookies?: Record<string, unknown>;
-	readonly headers?: Record<string, unknown>;
-	readonly query?: Record<string, unknown>;
-	readonly formData?: Record<string, unknown>;
-	readonly body?: any;
-	readonly mediaType?: string;
-	readonly responseHeader?: string;
-	readonly errors?: Record<number, string>;
-};
+  readonly method:
+    | "GET"
+    | "PUT"
+    | "POST"
+    | "DELETE"
+    | "OPTIONS"
+    | "HEAD"
+    | "PATCH"
+  readonly url: string
+  readonly path?: Record<string, unknown>
+  readonly cookies?: Record<string, unknown>
+  readonly headers?: Record<string, unknown>
+  readonly query?: Record<string, unknown>
+  readonly formData?: Record<string, unknown>
+  readonly body?: any
+  readonly mediaType?: string
+  readonly responseHeader?: string
+  readonly errors?: Record<number, string>
+}

--- a/frontend/src/client/core/ApiResult.ts
+++ b/frontend/src/client/core/ApiResult.ts
@@ -1,7 +1,7 @@
 export type ApiResult<TData = any> = {
-	readonly body: TData;
-	readonly ok: boolean;
-	readonly status: number;
-	readonly statusText: string;
-	readonly url: string;
-};
+  readonly body: TData
+  readonly ok: boolean
+  readonly status: number
+  readonly statusText: string
+  readonly url: string
+}

--- a/frontend/src/client/core/CancelablePromise.ts
+++ b/frontend/src/client/core/CancelablePromise.ts
@@ -1,126 +1,126 @@
 export class CancelError extends Error {
-	constructor(message: string) {
-		super(message);
-		this.name = 'CancelError';
-	}
+  constructor(message: string) {
+    super(message)
+    this.name = "CancelError"
+  }
 
-	public get isCancelled(): boolean {
-		return true;
-	}
+  public get isCancelled(): boolean {
+    return true
+  }
 }
 
 export interface OnCancel {
-	readonly isResolved: boolean;
-	readonly isRejected: boolean;
-	readonly isCancelled: boolean;
+  readonly isResolved: boolean
+  readonly isRejected: boolean
+  readonly isCancelled: boolean
 
-	(cancelHandler: () => void): void;
+  (cancelHandler: () => void): void
 }
 
 export class CancelablePromise<T> implements Promise<T> {
-	private _isResolved: boolean;
-	private _isRejected: boolean;
-	private _isCancelled: boolean;
-	readonly cancelHandlers: (() => void)[];
-	readonly promise: Promise<T>;
-	private _resolve?: (value: T | PromiseLike<T>) => void;
-	private _reject?: (reason?: unknown) => void;
+  private _isResolved: boolean
+  private _isRejected: boolean
+  private _isCancelled: boolean
+  readonly cancelHandlers: (() => void)[]
+  readonly promise: Promise<T>
+  private _resolve?: (value: T | PromiseLike<T>) => void
+  private _reject?: (reason?: unknown) => void
 
-	constructor(
-		executor: (
-			resolve: (value: T | PromiseLike<T>) => void,
-			reject: (reason?: unknown) => void,
-			onCancel: OnCancel
-		) => void
-	) {
-		this._isResolved = false;
-		this._isRejected = false;
-		this._isCancelled = false;
-		this.cancelHandlers = [];
-		this.promise = new Promise<T>((resolve, reject) => {
-			this._resolve = resolve;
-			this._reject = reject;
+  constructor(
+    executor: (
+      resolve: (value: T | PromiseLike<T>) => void,
+      reject: (reason?: unknown) => void,
+      onCancel: OnCancel,
+    ) => void,
+  ) {
+    this._isResolved = false
+    this._isRejected = false
+    this._isCancelled = false
+    this.cancelHandlers = []
+    this.promise = new Promise<T>((resolve, reject) => {
+      this._resolve = resolve
+      this._reject = reject
 
-			const onResolve = (value: T | PromiseLike<T>): void => {
-				if (this._isResolved || this._isRejected || this._isCancelled) {
-					return;
-				}
-				this._isResolved = true;
-				if (this._resolve) this._resolve(value);
-			};
+      const onResolve = (value: T | PromiseLike<T>): void => {
+        if (this._isResolved || this._isRejected || this._isCancelled) {
+          return
+        }
+        this._isResolved = true
+        if (this._resolve) this._resolve(value)
+      }
 
-			const onReject = (reason?: unknown): void => {
-				if (this._isResolved || this._isRejected || this._isCancelled) {
-					return;
-				}
-				this._isRejected = true;
-				if (this._reject) this._reject(reason);
-			};
+      const onReject = (reason?: unknown): void => {
+        if (this._isResolved || this._isRejected || this._isCancelled) {
+          return
+        }
+        this._isRejected = true
+        if (this._reject) this._reject(reason)
+      }
 
-			const onCancel = (cancelHandler: () => void): void => {
-				if (this._isResolved || this._isRejected || this._isCancelled) {
-					return;
-				}
-				this.cancelHandlers.push(cancelHandler);
-			};
+      const onCancel = (cancelHandler: () => void): void => {
+        if (this._isResolved || this._isRejected || this._isCancelled) {
+          return
+        }
+        this.cancelHandlers.push(cancelHandler)
+      }
 
-			Object.defineProperty(onCancel, 'isResolved', {
-				get: (): boolean => this._isResolved,
-			});
+      Object.defineProperty(onCancel, "isResolved", {
+        get: (): boolean => this._isResolved,
+      })
 
-			Object.defineProperty(onCancel, 'isRejected', {
-				get: (): boolean => this._isRejected,
-			});
+      Object.defineProperty(onCancel, "isRejected", {
+        get: (): boolean => this._isRejected,
+      })
 
-			Object.defineProperty(onCancel, 'isCancelled', {
-				get: (): boolean => this._isCancelled,
-			});
+      Object.defineProperty(onCancel, "isCancelled", {
+        get: (): boolean => this._isCancelled,
+      })
 
-			return executor(onResolve, onReject, onCancel as OnCancel);
-		});
-	}
+      return executor(onResolve, onReject, onCancel as OnCancel)
+    })
+  }
 
-	get [Symbol.toStringTag]() {
-		return "Cancellable Promise";
-	}
+  get [Symbol.toStringTag]() {
+    return "Cancellable Promise"
+  }
 
-	public then<TResult1 = T, TResult2 = never>(
-		onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
-		onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
-	): Promise<TResult1 | TResult2> {
-		return this.promise.then(onFulfilled, onRejected);
-	}
+  public then<TResult1 = T, TResult2 = never>(
+    onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.promise.then(onFulfilled, onRejected)
+  }
 
-	public catch<TResult = never>(
-		onRejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null
-	): Promise<T | TResult> {
-		return this.promise.catch(onRejected);
-	}
+  public catch<TResult = never>(
+    onRejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<T | TResult> {
+    return this.promise.catch(onRejected)
+  }
 
-	public finally(onFinally?: (() => void) | null): Promise<T> {
-		return this.promise.finally(onFinally);
-	}
+  public finally(onFinally?: (() => void) | null): Promise<T> {
+    return this.promise.finally(onFinally)
+  }
 
-	public cancel(): void {
-		if (this._isResolved || this._isRejected || this._isCancelled) {
-			return;
-		}
-		this._isCancelled = true;
-		if (this.cancelHandlers.length) {
-			try {
-				for (const cancelHandler of this.cancelHandlers) {
-					cancelHandler();
-				}
-			} catch (error) {
-				console.warn('Cancellation threw an error', error);
-				return;
-			}
-		}
-		this.cancelHandlers.length = 0;
-		if (this._reject) this._reject(new CancelError('Request aborted'));
-	}
+  public cancel(): void {
+    if (this._isResolved || this._isRejected || this._isCancelled) {
+      return
+    }
+    this._isCancelled = true
+    if (this.cancelHandlers.length) {
+      try {
+        for (const cancelHandler of this.cancelHandlers) {
+          cancelHandler()
+        }
+      } catch (error) {
+        console.warn("Cancellation threw an error", error)
+        return
+      }
+    }
+    this.cancelHandlers.length = 0
+    if (this._reject) this._reject(new CancelError("Request aborted"))
+  }
 
-	public get isCancelled(): boolean {
-		return this._isCancelled;
-	}
+  public get isCancelled(): boolean {
+    return this._isCancelled
+  }
 }

--- a/frontend/src/client/core/OpenAPI.ts
+++ b/frontend/src/client/core/OpenAPI.ts
@@ -1,58 +1,57 @@
-import type { AxiosRequestConfig, AxiosResponse } from 'axios';import type { ApiRequestOptions } from './ApiRequestOptions';
-import type { TResult } from './types';
+import type { AxiosRequestConfig, AxiosResponse } from "axios"
+import type { ApiRequestOptions } from "./ApiRequestOptions"
+import type { TResult } from "./types"
 
-type Headers = Record<string, string>;
-type Middleware<T> = (value: T) => T | Promise<T>;
-type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>
+type Middleware<T> = (value: T) => T | Promise<T>
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>
 
 export class Interceptors<T> {
-  _fns: Middleware<T>[];
+  _fns: Middleware<T>[]
 
   constructor() {
-    this._fns = [];
+    this._fns = []
   }
 
   eject(fn: Middleware<T>) {
-    const index = this._fns.indexOf(fn);
+    const index = this._fns.indexOf(fn)
     if (index !== -1) {
-      this._fns = [
-        ...this._fns.slice(0, index),
-        ...this._fns.slice(index + 1),
-      ];
+      this._fns = [...this._fns.slice(0, index), ...this._fns.slice(index + 1)]
     }
   }
 
   use(fn: Middleware<T>) {
-    this._fns = [...this._fns, fn];
+    this._fns = [...this._fns, fn]
   }
 }
 
 export type OpenAPIConfig = {
-	BASE: string;
-	CREDENTIALS: 'include' | 'omit' | 'same-origin';
-	ENCODE_PATH?: ((path: string) => string) | undefined;
-	HEADERS?: Headers | Resolver<Headers> | undefined;
-	PASSWORD?: string | Resolver<string> | undefined;
-	RESULT?: TResult;
-	TOKEN?: string | Resolver<string> | undefined;
-	USERNAME?: string | Resolver<string> | undefined;
-	VERSION: string;
-	WITH_CREDENTIALS: boolean;
-	interceptors: {request: Interceptors<AxiosRequestConfig>;
-		response: Interceptors<AxiosResponse>;};
-};
+  BASE: string
+  CREDENTIALS: "include" | "omit" | "same-origin"
+  ENCODE_PATH?: ((path: string) => string) | undefined
+  HEADERS?: Headers | Resolver<Headers> | undefined
+  PASSWORD?: string | Resolver<string> | undefined
+  RESULT?: TResult
+  TOKEN?: string | Resolver<string> | undefined
+  USERNAME?: string | Resolver<string> | undefined
+  VERSION: string
+  WITH_CREDENTIALS: boolean
+  interceptors: {
+    request: Interceptors<AxiosRequestConfig>
+    response: Interceptors<AxiosResponse>
+  }
+}
 
 export const OpenAPI: OpenAPIConfig = {
-	BASE: '',
-	CREDENTIALS: 'include',
-	ENCODE_PATH: undefined,
-	HEADERS: undefined,
-	PASSWORD: undefined,
-	RESULT: 'body',
-	TOKEN: undefined,
-	USERNAME: undefined,
-	VERSION: '0.1.0',
-	WITH_CREDENTIALS: false,
-	interceptors: {request: new Interceptors(),response: new Interceptors(),
-	},
-};
+  BASE: "",
+  CREDENTIALS: "include",
+  ENCODE_PATH: undefined,
+  HEADERS: undefined,
+  PASSWORD: undefined,
+  RESULT: "body",
+  TOKEN: undefined,
+  USERNAME: undefined,
+  VERSION: "0.1.0",
+  WITH_CREDENTIALS: false,
+  interceptors: { request: new Interceptors(), response: new Interceptors() },
+}

--- a/frontend/src/client/core/request.ts
+++ b/frontend/src/client/core/request.ts
@@ -1,295 +1,319 @@
-import axios from 'axios';
-import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
+import axios from "axios"
+import type {
+  AxiosError,
+  AxiosRequestConfig,
+  AxiosResponse,
+  AxiosInstance,
+} from "axios"
 
-import { ApiError } from './ApiError';
-import type { ApiRequestOptions } from './ApiRequestOptions';
-import type { ApiResult } from './ApiResult';
-import { CancelablePromise } from './CancelablePromise';
-import type { OnCancel } from './CancelablePromise';
-import type { OpenAPIConfig } from './OpenAPI';
+import { ApiError } from "./ApiError"
+import type { ApiRequestOptions } from "./ApiRequestOptions"
+import type { ApiResult } from "./ApiResult"
+import { CancelablePromise } from "./CancelablePromise"
+import type { OnCancel } from "./CancelablePromise"
+import type { OpenAPIConfig } from "./OpenAPI"
 
 export const isString = (value: unknown): value is string => {
-	return typeof value === 'string';
-};
+  return typeof value === "string"
+}
 
 export const isStringWithValue = (value: unknown): value is string => {
-	return isString(value) && value !== '';
-};
+  return isString(value) && value !== ""
+}
 
 export const isBlob = (value: any): value is Blob => {
-	return value instanceof Blob;
-};
+  return value instanceof Blob
+}
 
 export const isFormData = (value: unknown): value is FormData => {
-	return value instanceof FormData;
-};
+  return value instanceof FormData
+}
 
 export const isSuccess = (status: number): boolean => {
-	return status >= 200 && status < 300;
-};
+  return status >= 200 && status < 300
+}
 
 export const base64 = (str: string): string => {
-	try {
-		return btoa(str);
-	} catch (err) {
-		// @ts-ignore
-		return Buffer.from(str).toString('base64');
-	}
-};
+  try {
+    return btoa(str)
+  } catch (err) {
+    // @ts-ignore
+    return Buffer.from(str).toString("base64")
+  }
+}
 
 export const getQueryString = (params: Record<string, unknown>): string => {
-	const qs: string[] = [];
+  const qs: string[] = []
 
-	const append = (key: string, value: unknown) => {
-		qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
-	};
+  const append = (key: string, value: unknown) => {
+    qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+  }
 
-	const encodePair = (key: string, value: unknown) => {
-		if (value === undefined || value === null) {
-			return;
-		}
+  const encodePair = (key: string, value: unknown) => {
+    if (value === undefined || value === null) {
+      return
+    }
 
-		if (Array.isArray(value)) {
-			value.forEach(v => encodePair(key, v));
-		} else if (typeof value === 'object') {
-			Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v));
-		} else {
-			append(key, value);
-		}
-	};
+    if (Array.isArray(value)) {
+      value.forEach((v) => encodePair(key, v))
+    } else if (typeof value === "object") {
+      Object.entries(value).forEach(([k, v]) => encodePair(`${key}[${k}]`, v))
+    } else {
+      append(key, value)
+    }
+  }
 
-	Object.entries(params).forEach(([key, value]) => encodePair(key, value));
+  Object.entries(params).forEach(([key, value]) => encodePair(key, value))
 
-	return qs.length ? `?${qs.join('&')}` : '';
-};
+  return qs.length ? `?${qs.join("&")}` : ""
+}
 
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
-	const encoder = config.ENCODE_PATH || encodeURI;
+  const encoder = config.ENCODE_PATH || encodeURI
 
-	const path = options.url
-		.replace('{api-version}', config.VERSION)
-		.replace(/{(.*?)}/g, (substring: string, group: string) => {
-			if (options.path?.hasOwnProperty(group)) {
-				return encoder(String(options.path[group]));
-			}
-			return substring;
-		});
+  const path = options.url
+    .replace("{api-version}", config.VERSION)
+    .replace(/{(.*?)}/g, (substring: string, group: string) => {
+      if (options.path?.hasOwnProperty(group)) {
+        return encoder(String(options.path[group]))
+      }
+      return substring
+    })
 
-	const url = config.BASE + path;
-	return options.query ? url + getQueryString(options.query) : url;
-};
+  const url = config.BASE + path
+  return options.query ? url + getQueryString(options.query) : url
+}
 
-export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
-	if (options.formData) {
-		const formData = new FormData();
+export const getFormData = (
+  options: ApiRequestOptions,
+): FormData | undefined => {
+  if (options.formData) {
+    const formData = new FormData()
 
-		const process = (key: string, value: unknown) => {
-			if (isString(value) || isBlob(value)) {
-				formData.append(key, value);
-			} else {
-				formData.append(key, JSON.stringify(value));
-			}
-		};
+    const process = (key: string, value: unknown) => {
+      if (isString(value) || isBlob(value)) {
+        formData.append(key, value)
+      } else {
+        formData.append(key, JSON.stringify(value))
+      }
+    }
 
-		Object.entries(options.formData)
-			.filter(([, value]) => value !== undefined && value !== null)
-			.forEach(([key, value]) => {
-				if (Array.isArray(value)) {
-					value.forEach(v => process(key, v));
-				} else {
-					process(key, value);
-				}
-			});
+    Object.entries(options.formData)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .forEach(([key, value]) => {
+        if (Array.isArray(value)) {
+          value.forEach((v) => process(key, v))
+        } else {
+          process(key, value)
+        }
+      })
 
-		return formData;
-	}
-	return undefined;
-};
+    return formData
+  }
+  return undefined
+}
 
-type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>
 
-export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
-	if (typeof resolver === 'function') {
-		return (resolver as Resolver<T>)(options);
-	}
-	return resolver;
-};
+export const resolve = async <T>(
+  options: ApiRequestOptions,
+  resolver?: T | Resolver<T>,
+): Promise<T | undefined> => {
+  if (typeof resolver === "function") {
+    return (resolver as Resolver<T>)(options)
+  }
+  return resolver
+}
 
-export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Record<string, string>> => {
-	const [token, username, password, additionalHeaders] = await Promise.all([
-		resolve(options, config.TOKEN),
-		resolve(options, config.USERNAME),
-		resolve(options, config.PASSWORD),
-		resolve(options, config.HEADERS),
-	]);
+export const getHeaders = async (
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+): Promise<Record<string, string>> => {
+  const [token, username, password, additionalHeaders] = await Promise.all([
+    resolve(options, config.TOKEN),
+    resolve(options, config.USERNAME),
+    resolve(options, config.PASSWORD),
+    resolve(options, config.HEADERS),
+  ])
 
-	const headers = Object.entries({
-		Accept: 'application/json',
-		...additionalHeaders,
-		...options.headers,
-	})
-	.filter(([, value]) => value !== undefined && value !== null)
-	.reduce((headers, [key, value]) => ({
-		...headers,
-		[key]: String(value),
-	}), {} as Record<string, string>);
+  const headers = Object.entries({
+    Accept: "application/json",
+    ...additionalHeaders,
+    ...options.headers,
+  })
+    .filter(([, value]) => value !== undefined && value !== null)
+    .reduce(
+      (headers, [key, value]) => ({
+        ...headers,
+        [key]: String(value),
+      }),
+      {} as Record<string, string>,
+    )
 
-	if (isStringWithValue(token)) {
-		headers['Authorization'] = `Bearer ${token}`;
-	}
+  if (isStringWithValue(token)) {
+    headers["Authorization"] = `Bearer ${token}`
+  }
 
-	if (isStringWithValue(username) && isStringWithValue(password)) {
-		const credentials = base64(`${username}:${password}`);
-		headers['Authorization'] = `Basic ${credentials}`;
-	}
+  if (isStringWithValue(username) && isStringWithValue(password)) {
+    const credentials = base64(`${username}:${password}`)
+    headers["Authorization"] = `Basic ${credentials}`
+  }
 
-	if (options.body !== undefined) {
-		if (options.mediaType) {
-			headers['Content-Type'] = options.mediaType;
-		} else if (isBlob(options.body)) {
-			headers['Content-Type'] = options.body.type || 'application/octet-stream';
-		} else if (isString(options.body)) {
-			headers['Content-Type'] = 'text/plain';
-		} else if (!isFormData(options.body)) {
-			headers['Content-Type'] = 'application/json';
-		}
-	} else if (options.formData !== undefined) {
-		if (options.mediaType) {
-			headers['Content-Type'] = options.mediaType;
-		}
-	}
+  if (options.body !== undefined) {
+    if (options.mediaType) {
+      headers["Content-Type"] = options.mediaType
+    } else if (isBlob(options.body)) {
+      headers["Content-Type"] = options.body.type || "application/octet-stream"
+    } else if (isString(options.body)) {
+      headers["Content-Type"] = "text/plain"
+    } else if (!isFormData(options.body)) {
+      headers["Content-Type"] = "application/json"
+    }
+  } else if (options.formData !== undefined) {
+    if (options.mediaType) {
+      headers["Content-Type"] = options.mediaType
+    }
+  }
 
-	return headers;
-};
+  return headers
+}
 
 export const getRequestBody = (options: ApiRequestOptions): unknown => {
-	if (options.body) {
-		return options.body;
-	}
-	return undefined;
-};
+  if (options.body) {
+    return options.body
+  }
+  return undefined
+}
 
 export const sendRequest = async <T>(
-	config: OpenAPIConfig,
-	options: ApiRequestOptions,
-	url: string,
-	body: unknown,
-	formData: FormData | undefined,
-	headers: Record<string, string>,
-	onCancel: OnCancel,
-	axiosClient: AxiosInstance
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+  url: string,
+  body: unknown,
+  formData: FormData | undefined,
+  headers: Record<string, string>,
+  onCancel: OnCancel,
+  axiosClient: AxiosInstance,
 ): Promise<AxiosResponse<T>> => {
-	const controller = new AbortController();
+  const controller = new AbortController()
 
-	let requestConfig: AxiosRequestConfig = {
-		data: body ?? formData,
-		headers,
-		method: options.method,
-		signal: controller.signal,
-		url,
-		withCredentials: config.WITH_CREDENTIALS,
-	};
+  let requestConfig: AxiosRequestConfig = {
+    data: body ?? formData,
+    headers,
+    method: options.method,
+    signal: controller.signal,
+    url,
+    withCredentials: config.WITH_CREDENTIALS,
+  }
 
-	onCancel(() => controller.abort());
+  onCancel(() => controller.abort())
 
-	for (const fn of config.interceptors.request._fns) {
-		requestConfig = await fn(requestConfig)
-	}
+  for (const fn of config.interceptors.request._fns) {
+    requestConfig = await fn(requestConfig)
+  }
 
-	try {
-		return await axiosClient.request(requestConfig);
-	} catch (error) {
-		const axiosError = error as AxiosError<T>;
-		if (axiosError.response) {
-			return axiosError.response;
-		}
-		throw error;
-	}
-};
+  try {
+    return await axiosClient.request(requestConfig)
+  } catch (error) {
+    const axiosError = error as AxiosError<T>
+    if (axiosError.response) {
+      return axiosError.response
+    }
+    throw error
+  }
+}
 
-export const getResponseHeader = (response: AxiosResponse<unknown>, responseHeader?: string): string | undefined => {
-	if (responseHeader) {
-		const content = response.headers[responseHeader];
-		if (isString(content)) {
-			return content;
-		}
-	}
-	return undefined;
-};
+export const getResponseHeader = (
+  response: AxiosResponse<unknown>,
+  responseHeader?: string,
+): string | undefined => {
+  if (responseHeader) {
+    const content = response.headers[responseHeader]
+    if (isString(content)) {
+      return content
+    }
+  }
+  return undefined
+}
 
 export const getResponseBody = (response: AxiosResponse<unknown>): unknown => {
-	if (response.status !== 204) {
-		return response.data;
-	}
-	return undefined;
-};
+  if (response.status !== 204) {
+    return response.data
+  }
+  return undefined
+}
 
-export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
-	const errors: Record<number, string> = {
-		400: 'Bad Request',
-		401: 'Unauthorized',
-		402: 'Payment Required',
-		403: 'Forbidden',
-		404: 'Not Found',
-		405: 'Method Not Allowed',
-		406: 'Not Acceptable',
-		407: 'Proxy Authentication Required',
-		408: 'Request Timeout',
-		409: 'Conflict',
-		410: 'Gone',
-		411: 'Length Required',
-		412: 'Precondition Failed',
-		413: 'Payload Too Large',
-		414: 'URI Too Long',
-		415: 'Unsupported Media Type',
-		416: 'Range Not Satisfiable',
-		417: 'Expectation Failed',
-		418: 'Im a teapot',
-		421: 'Misdirected Request',
-		422: 'Unprocessable Content',
-		423: 'Locked',
-		424: 'Failed Dependency',
-		425: 'Too Early',
-		426: 'Upgrade Required',
-		428: 'Precondition Required',
-		429: 'Too Many Requests',
-		431: 'Request Header Fields Too Large',
-		451: 'Unavailable For Legal Reasons',
-		500: 'Internal Server Error',
-		501: 'Not Implemented',
-		502: 'Bad Gateway',
-		503: 'Service Unavailable',
-		504: 'Gateway Timeout',
-		505: 'HTTP Version Not Supported',
-		506: 'Variant Also Negotiates',
-		507: 'Insufficient Storage',
-		508: 'Loop Detected',
-		510: 'Not Extended',
-		511: 'Network Authentication Required',
-		...options.errors,
-	}
+export const catchErrorCodes = (
+  options: ApiRequestOptions,
+  result: ApiResult,
+): void => {
+  const errors: Record<number, string> = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    402: "Payment Required",
+    403: "Forbidden",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    406: "Not Acceptable",
+    407: "Proxy Authentication Required",
+    408: "Request Timeout",
+    409: "Conflict",
+    410: "Gone",
+    411: "Length Required",
+    412: "Precondition Failed",
+    413: "Payload Too Large",
+    414: "URI Too Long",
+    415: "Unsupported Media Type",
+    416: "Range Not Satisfiable",
+    417: "Expectation Failed",
+    418: "Im a teapot",
+    421: "Misdirected Request",
+    422: "Unprocessable Content",
+    423: "Locked",
+    424: "Failed Dependency",
+    425: "Too Early",
+    426: "Upgrade Required",
+    428: "Precondition Required",
+    429: "Too Many Requests",
+    431: "Request Header Fields Too Large",
+    451: "Unavailable For Legal Reasons",
+    500: "Internal Server Error",
+    501: "Not Implemented",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+    505: "HTTP Version Not Supported",
+    506: "Variant Also Negotiates",
+    507: "Insufficient Storage",
+    508: "Loop Detected",
+    510: "Not Extended",
+    511: "Network Authentication Required",
+    ...options.errors,
+  }
 
-	const error = errors[result.status];
-	if (error) {
-		throw new ApiError(options, result, error);
-	}
+  const error = errors[result.status]
+  if (error) {
+    throw new ApiError(options, result, error)
+  }
 
-	if (!result.ok) {
-		const errorStatus = result.status ?? 'unknown';
-		const errorStatusText = result.statusText ?? 'unknown';
-		const errorBody = (() => {
-			try {
-				return JSON.stringify(result.body, null, 2);
-			} catch (e) {
-				return undefined;
-			}
-		})();
+  if (!result.ok) {
+    const errorStatus = result.status ?? "unknown"
+    const errorStatusText = result.statusText ?? "unknown"
+    const errorBody = (() => {
+      try {
+        return JSON.stringify(result.body, null, 2)
+      } catch (e) {
+        return undefined
+      }
+    })()
 
-		throw new ApiError(options, result,
-			`Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
-		);
-	}
-};
+    throw new ApiError(
+      options,
+      result,
+      `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`,
+    )
+  }
+}
 
 /**
  * Request method
@@ -299,38 +323,54 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
  * @returns CancelablePromise<T>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
-	return new CancelablePromise(async (resolve, reject, onCancel) => {
-		try {
-			const url = getUrl(config, options);
-			const formData = getFormData(options);
-			const body = getRequestBody(options);
-			const headers = await getHeaders(config, options);
+export const request = <T>(
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+  axiosClient: AxiosInstance = axios,
+): CancelablePromise<T> => {
+  return new CancelablePromise(async (resolve, reject, onCancel) => {
+    try {
+      const url = getUrl(config, options)
+      const formData = getFormData(options)
+      const body = getRequestBody(options)
+      const headers = await getHeaders(config, options)
 
-			if (!onCancel.isCancelled) {
-				let response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel, axiosClient);
+      if (!onCancel.isCancelled) {
+        let response = await sendRequest<T>(
+          config,
+          options,
+          url,
+          body,
+          formData,
+          headers,
+          onCancel,
+          axiosClient,
+        )
 
-				for (const fn of config.interceptors.response._fns) {
-					response = await fn(response)
-				}
+        for (const fn of config.interceptors.response._fns) {
+          response = await fn(response)
+        }
 
-				const responseBody = getResponseBody(response);
-				const responseHeader = getResponseHeader(response, options.responseHeader);
+        const responseBody = getResponseBody(response)
+        const responseHeader = getResponseHeader(
+          response,
+          options.responseHeader,
+        )
 
-				const result: ApiResult = {
-					url,
-					ok: isSuccess(response.status),
-					status: response.status,
-					statusText: response.statusText,
-					body: responseHeader ?? responseBody,
-				};
+        const result: ApiResult = {
+          url,
+          ok: isSuccess(response.status),
+          status: response.status,
+          statusText: response.statusText,
+          body: responseHeader ?? responseBody,
+        }
 
-				catchErrorCodes(options, result);
+        catchErrorCodes(options, result)
 
-				resolve(result.body);
-			}
-		} catch (error) {
-			reject(error);
-		}
-	});
-};
+        resolve(result.body)
+      }
+    } catch (error) {
+      reject(error)
+    }
+  })
+}

--- a/frontend/src/client/core/types.ts
+++ b/frontend/src/client/core/types.ts
@@ -1,12 +1,14 @@
-import type { ApiResult } from './ApiResult';
+import type { ApiResult } from "./ApiResult"
 
-export type TResult = 'body' | 'raw';
+export type TResult = "body" | "raw"
 
-export type TApiResponse<T extends TResult, TData> =
-  Exclude<T, 'raw'> extends never
-    ? ApiResult<TData>
-    : ApiResult<TData>['body'];
+export type TApiResponse<T extends TResult, TData> = Exclude<
+  T,
+  "raw"
+> extends never
+  ? ApiResult<TData>
+  : ApiResult<TData>["body"]
 
 export type TConfig<T extends TResult> = {
-  _result?: T;
-};
+  _result?: T
+}

--- a/frontend/src/client/index.ts
+++ b/frontend/src/client/index.ts
@@ -1,9 +1,8 @@
+export { ApiError } from "./core/ApiError"
+export { CancelablePromise, CancelError } from "./core/CancelablePromise"
+export { OpenAPI } from "./core/OpenAPI"
+export type { OpenAPIConfig } from "./core/OpenAPI"
 
-export { ApiError } from './core/ApiError';
-export { CancelablePromise, CancelError } from './core/CancelablePromise';
-export { OpenAPI } from './core/OpenAPI';
-export type { OpenAPIConfig } from './core/OpenAPI';
-
-export * from './models'
-export * from './schemas'
-export * from './services'
+export * from "./models"
+export * from "./schemas"
+export * from "./services"

--- a/frontend/src/client/models.ts
+++ b/frontend/src/client/models.ts
@@ -1,132 +1,99 @@
 export type Body_login_login_access_token = {
-	grant_type?: string | null;
-	username: string;
-	password: string;
-	scope?: string;
-	client_id?: string | null;
-	client_secret?: string | null;
-};
-
-
+  grant_type?: string | null
+  username: string
+  password: string
+  scope?: string
+  client_id?: string | null
+  client_secret?: string | null
+}
 
 export type HTTPValidationError = {
-	detail?: Array<ValidationError>;
-};
-
-
+  detail?: Array<ValidationError>
+}
 
 export type ItemCreate = {
-	title: string;
-	description?: string | null;
-};
-
-
+  title: string
+  description?: string | null
+}
 
 export type ItemPublic = {
-	title: string;
-	description?: string | null;
-	id: number;
-	owner_id: number;
-};
-
-
+  title: string
+  description?: string | null
+  id: number
+  owner_id: number
+}
 
 export type ItemUpdate = {
-	title?: string | null;
-	description?: string | null;
-};
-
-
+  title?: string | null
+  description?: string | null
+}
 
 export type ItemsPublic = {
-	data: Array<ItemPublic>;
-	count: number;
-};
-
-
+  data: Array<ItemPublic>
+  count: number
+}
 
 export type Message = {
-	message: string;
-};
-
-
+  message: string
+}
 
 export type NewPassword = {
-	token: string;
-	new_password: string;
-};
-
-
+  token: string
+  new_password: string
+}
 
 export type Token = {
-	access_token: string;
-	token_type?: string;
-};
-
-
+  access_token: string
+  token_type?: string
+}
 
 export type UpdatePassword = {
-	current_password: string;
-	new_password: string;
-};
-
-
+  current_password: string
+  new_password: string
+}
 
 export type UserCreate = {
-	email: string;
-	is_active?: boolean;
-	is_superuser?: boolean;
-	full_name?: string | null;
-	password: string;
-};
-
-
+  email: string
+  is_active?: boolean
+  is_superuser?: boolean
+  full_name?: string | null
+  password: string
+}
 
 export type UserPublic = {
-	email: string;
-	is_active?: boolean;
-	is_superuser?: boolean;
-	full_name?: string | null;
-	id: number;
-};
-
-
+  email: string
+  is_active?: boolean
+  is_superuser?: boolean
+  full_name?: string | null
+  id: number
+}
 
 export type UserRegister = {
-	email: string;
-	password: string;
-	full_name?: string | null;
-};
-
-
+  email: string
+  password: string
+  full_name?: string | null
+}
 
 export type UserUpdate = {
-	email?: string | null;
-	is_active?: boolean;
-	is_superuser?: boolean;
-	full_name?: string | null;
-	password?: string | null;
-};
-
-
+  email?: string | null
+  is_active?: boolean
+  is_superuser?: boolean
+  full_name?: string | null
+  password?: string | null
+}
 
 export type UserUpdateMe = {
-	full_name?: string | null;
-	email?: string | null;
-};
-
-
+  full_name?: string | null
+  email?: string | null
+}
 
 export type UsersPublic = {
-	data: Array<UserPublic>;
-	count: number;
-};
-
-
+  data: Array<UserPublic>
+  count: number
+}
 
 export type ValidationError = {
-	loc: Array<string | number>;
-	msg: string;
-	type: string;
-};
-
+  loc: Array<string | number>
+  msg: string
+  type: string
+}

--- a/frontend/src/client/schemas.ts
+++ b/frontend/src/client/schemas.ts
@@ -1,357 +1,405 @@
 export const $Body_login_login_access_token = {
-	properties: {
-		grant_type: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-	pattern: 'password',
-}, {
-	type: 'null',
-}],
-},
-		username: {
-	type: 'string',
-	isRequired: true,
-},
-		password: {
-	type: 'string',
-	isRequired: true,
-},
-		scope: {
-	type: 'string',
-	default: '',
-},
-		client_id: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-		client_secret: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-	},
-} as const;
+  properties: {
+    grant_type: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+          pattern: "password",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    username: {
+      type: "string",
+      isRequired: true,
+    },
+    password: {
+      type: "string",
+      isRequired: true,
+    },
+    scope: {
+      type: "string",
+      default: "",
+    },
+    client_id: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    client_secret: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+} as const
 
 export const $HTTPValidationError = {
-	properties: {
-		detail: {
-	type: 'array',
-	contains: {
-		type: 'ValidationError',
-	},
-},
-	},
-} as const;
+  properties: {
+    detail: {
+      type: "array",
+      contains: {
+        type: "ValidationError",
+      },
+    },
+  },
+} as const
 
 export const $ItemCreate = {
-	properties: {
-		title: {
-	type: 'string',
-	isRequired: true,
-},
-		description: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-	},
-} as const;
+  properties: {
+    title: {
+      type: "string",
+      isRequired: true,
+    },
+    description: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+} as const
 
 export const $ItemPublic = {
-	properties: {
-		title: {
-	type: 'string',
-	isRequired: true,
-},
-		description: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-		id: {
-	type: 'number',
-	isRequired: true,
-},
-		owner_id: {
-	type: 'number',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    title: {
+      type: "string",
+      isRequired: true,
+    },
+    description: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    id: {
+      type: "number",
+      isRequired: true,
+    },
+    owner_id: {
+      type: "number",
+      isRequired: true,
+    },
+  },
+} as const
 
 export const $ItemUpdate = {
-	properties: {
-		title: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-		description: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-	},
-} as const;
+  properties: {
+    title: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    description: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+} as const
 
 export const $ItemsPublic = {
-	properties: {
-		data: {
-	type: 'array',
-	contains: {
-		type: 'ItemPublic',
-	},
-	isRequired: true,
-},
-		count: {
-	type: 'number',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    data: {
+      type: "array",
+      contains: {
+        type: "ItemPublic",
+      },
+      isRequired: true,
+    },
+    count: {
+      type: "number",
+      isRequired: true,
+    },
+  },
+} as const
 
 export const $Message = {
-	properties: {
-		message: {
-	type: 'string',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    message: {
+      type: "string",
+      isRequired: true,
+    },
+  },
+} as const
 
 export const $NewPassword = {
-	properties: {
-		token: {
-	type: 'string',
-	isRequired: true,
-},
-		new_password: {
-	type: 'string',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    token: {
+      type: "string",
+      isRequired: true,
+    },
+    new_password: {
+      type: "string",
+      isRequired: true,
+    },
+  },
+} as const
 
 export const $Token = {
-	properties: {
-		access_token: {
-	type: 'string',
-	isRequired: true,
-},
-		token_type: {
-	type: 'string',
-	default: 'bearer',
-},
-	},
-} as const;
+  properties: {
+    access_token: {
+      type: "string",
+      isRequired: true,
+    },
+    token_type: {
+      type: "string",
+      default: "bearer",
+    },
+  },
+} as const
 
 export const $UpdatePassword = {
-	properties: {
-		current_password: {
-	type: 'string',
-	isRequired: true,
-},
-		new_password: {
-	type: 'string',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    current_password: {
+      type: "string",
+      isRequired: true,
+    },
+    new_password: {
+      type: "string",
+      isRequired: true,
+    },
+  },
+} as const
 
 export const $UserCreate = {
-	properties: {
-		email: {
-	type: 'string',
-	isRequired: true,
-},
-		is_active: {
-	type: 'boolean',
-	default: true,
-},
-		is_superuser: {
-	type: 'boolean',
-	default: false,
-},
-		full_name: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-		password: {
-	type: 'string',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    email: {
+      type: "string",
+      isRequired: true,
+    },
+    is_active: {
+      type: "boolean",
+      default: true,
+    },
+    is_superuser: {
+      type: "boolean",
+      default: false,
+    },
+    full_name: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    password: {
+      type: "string",
+      isRequired: true,
+    },
+  },
+} as const
 
 export const $UserPublic = {
-	properties: {
-		email: {
-	type: 'string',
-	isRequired: true,
-},
-		is_active: {
-	type: 'boolean',
-	default: true,
-},
-		is_superuser: {
-	type: 'boolean',
-	default: false,
-},
-		full_name: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-		id: {
-	type: 'number',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    email: {
+      type: "string",
+      isRequired: true,
+    },
+    is_active: {
+      type: "boolean",
+      default: true,
+    },
+    is_superuser: {
+      type: "boolean",
+      default: false,
+    },
+    full_name: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    id: {
+      type: "number",
+      isRequired: true,
+    },
+  },
+} as const
 
 export const $UserRegister = {
-	properties: {
-		email: {
-	type: 'string',
-	isRequired: true,
-},
-		password: {
-	type: 'string',
-	isRequired: true,
-},
-		full_name: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-	},
-} as const;
+  properties: {
+    email: {
+      type: "string",
+      isRequired: true,
+    },
+    password: {
+      type: "string",
+      isRequired: true,
+    },
+    full_name: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+} as const
 
 export const $UserUpdate = {
-	properties: {
-		email: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-		is_active: {
-	type: 'boolean',
-	default: true,
-},
-		is_superuser: {
-	type: 'boolean',
-	default: false,
-},
-		full_name: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-		password: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-	},
-} as const;
+  properties: {
+    email: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    is_active: {
+      type: "boolean",
+      default: true,
+    },
+    is_superuser: {
+      type: "boolean",
+      default: false,
+    },
+    full_name: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    password: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+} as const
 
 export const $UserUpdateMe = {
-	properties: {
-		full_name: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-		email: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'null',
-}],
-},
-	},
-} as const;
+  properties: {
+    full_name: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    email: {
+      type: "any-of",
+      contains: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+} as const
 
 export const $UsersPublic = {
-	properties: {
-		data: {
-	type: 'array',
-	contains: {
-		type: 'UserPublic',
-	},
-	isRequired: true,
-},
-		count: {
-	type: 'number',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    data: {
+      type: "array",
+      contains: {
+        type: "UserPublic",
+      },
+      isRequired: true,
+    },
+    count: {
+      type: "number",
+      isRequired: true,
+    },
+  },
+} as const
 
 export const $ValidationError = {
-	properties: {
-		loc: {
-	type: 'array',
-	contains: {
-	type: 'any-of',
-	contains: [{
-	type: 'string',
-}, {
-	type: 'number',
-}],
-},
-	isRequired: true,
-},
-		msg: {
-	type: 'string',
-	isRequired: true,
-},
-		type: {
-	type: 'string',
-	isRequired: true,
-},
-	},
-} as const;
+  properties: {
+    loc: {
+      type: "array",
+      contains: {
+        type: "any-of",
+        contains: [
+          {
+            type: "string",
+          },
+          {
+            type: "number",
+          },
+        ],
+      },
+      isRequired: true,
+    },
+    msg: {
+      type: "string",
+      isRequired: true,
+    },
+    type: {
+      type: "string",
+      isRequired: true,
+    },
+  },
+} as const

--- a/frontend/src/client/services.ts
+++ b/frontend/src/client/services.ts
@@ -1,537 +1,517 @@
-import type { CancelablePromise } from './core/CancelablePromise';
-import { OpenAPI } from './core/OpenAPI';
-import { request as __request } from './core/request';
+import type { CancelablePromise } from "./core/CancelablePromise"
+import { OpenAPI } from "./core/OpenAPI"
+import { request as __request } from "./core/request"
 
-import type { Body_login_login_access_token,Message,NewPassword,Token,UserPublic,UpdatePassword,UserCreate,UserRegister,UsersPublic,UserUpdate,UserUpdateMe,ItemCreate,ItemPublic,ItemsPublic,ItemUpdate } from './models';
+import type {
+  Body_login_login_access_token,
+  Message,
+  NewPassword,
+  Token,
+  UserPublic,
+  UpdatePassword,
+  UserCreate,
+  UserRegister,
+  UsersPublic,
+  UserUpdate,
+  UserUpdateMe,
+  ItemCreate,
+  ItemPublic,
+  ItemsPublic,
+  ItemUpdate,
+} from "./models"
 
 export type TDataLoginAccessToken = {
-                formData: Body_login_login_access_token
-                
-            }
+  formData: Body_login_login_access_token
+}
 export type TDataRecoverPassword = {
-                email: string
-                
-            }
+  email: string
+}
 export type TDataResetPassword = {
-                requestBody: NewPassword
-                
-            }
+  requestBody: NewPassword
+}
 export type TDataRecoverPasswordHtmlContent = {
-                email: string
-                
-            }
+  email: string
+}
 
 export class LoginService {
+  /**
+   * Login Access Token
+   * OAuth2 compatible token login, get an access token for future requests
+   * @returns Token Successful Response
+   * @throws ApiError
+   */
+  public static loginAccessToken(
+    data: TDataLoginAccessToken,
+  ): CancelablePromise<Token> {
+    const { formData } = data
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/login/access-token",
+      formData: formData,
+      mediaType: "application/x-www-form-urlencoded",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Login Access Token
-	 * OAuth2 compatible token login, get an access token for future requests
-	 * @returns Token Successful Response
-	 * @throws ApiError
-	 */
-	public static loginAccessToken(data: TDataLoginAccessToken): CancelablePromise<Token> {
-		const {
-formData,
-} = data;
-		return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/login/access-token',
-			formData: formData,
-			mediaType: 'application/x-www-form-urlencoded',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Test Token
+   * Test access token
+   * @returns UserPublic Successful Response
+   * @throws ApiError
+   */
+  public static testToken(): CancelablePromise<UserPublic> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/login/test-token",
+    })
+  }
 
-	/**
-	 * Test Token
-	 * Test access token
-	 * @returns UserPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static testToken(): CancelablePromise<UserPublic> {
-				return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/login/test-token',
-		});
-	}
+  /**
+   * Recover Password
+   * Password Recovery
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static recoverPassword(
+    data: TDataRecoverPassword,
+  ): CancelablePromise<Message> {
+    const { email } = data
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/password-recovery/{email}",
+      path: {
+        email,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Recover Password
-	 * Password Recovery
-	 * @returns Message Successful Response
-	 * @throws ApiError
-	 */
-	public static recoverPassword(data: TDataRecoverPassword): CancelablePromise<Message> {
-		const {
-email,
-} = data;
-		return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/password-recovery/{email}',
-			path: {
-				email
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Reset Password
+   * Reset password
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static resetPassword(
+    data: TDataResetPassword,
+  ): CancelablePromise<Message> {
+    const { requestBody } = data
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/reset-password/",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Reset Password
-	 * Reset password
-	 * @returns Message Successful Response
-	 * @throws ApiError
-	 */
-	public static resetPassword(data: TDataResetPassword): CancelablePromise<Message> {
-		const {
-requestBody,
-} = data;
-		return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/reset-password/',
-			body: requestBody,
-			mediaType: 'application/json',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
-
-	/**
-	 * Recover Password Html Content
-	 * HTML Content for Password Recovery
-	 * @returns string Successful Response
-	 * @throws ApiError
-	 */
-	public static recoverPasswordHtmlContent(data: TDataRecoverPasswordHtmlContent): CancelablePromise<string> {
-		const {
-email,
-} = data;
-		return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/password-recovery-html-content/{email}',
-			path: {
-				email
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
-
+  /**
+   * Recover Password Html Content
+   * HTML Content for Password Recovery
+   * @returns string Successful Response
+   * @throws ApiError
+   */
+  public static recoverPasswordHtmlContent(
+    data: TDataRecoverPasswordHtmlContent,
+  ): CancelablePromise<string> {
+    const { email } = data
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/password-recovery-html-content/{email}",
+      path: {
+        email,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 }
 
 export type TDataReadUsers = {
-                limit?: number
-skip?: number
-                
-            }
+  limit?: number
+  skip?: number
+}
 export type TDataCreateUser = {
-                requestBody: UserCreate
-                
-            }
+  requestBody: UserCreate
+}
 export type TDataUpdateUserMe = {
-                requestBody: UserUpdateMe
-                
-            }
+  requestBody: UserUpdateMe
+}
 export type TDataUpdatePasswordMe = {
-                requestBody: UpdatePassword
-                
-            }
+  requestBody: UpdatePassword
+}
 export type TDataRegisterUser = {
-                requestBody: UserRegister
-                
-            }
+  requestBody: UserRegister
+}
 export type TDataReadUserById = {
-                userId: number
-                
-            }
+  userId: number
+}
 export type TDataUpdateUser = {
-                requestBody: UserUpdate
-userId: number
-                
-            }
+  requestBody: UserUpdate
+  userId: number
+}
 export type TDataDeleteUser = {
-                userId: number
-                
-            }
+  userId: number
+}
 
 export class UsersService {
+  /**
+   * Read Users
+   * Retrieve users.
+   * @returns UsersPublic Successful Response
+   * @throws ApiError
+   */
+  public static readUsers(
+    data: TDataReadUsers = {},
+  ): CancelablePromise<UsersPublic> {
+    const { limit = 100, skip = 0 } = data
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/users/",
+      query: {
+        skip,
+        limit,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Read Users
-	 * Retrieve users.
-	 * @returns UsersPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static readUsers(data: TDataReadUsers = {}): CancelablePromise<UsersPublic> {
-		const {
-limit = 100,
-skip = 0,
-} = data;
-		return __request(OpenAPI, {
-			method: 'GET',
-			url: '/api/v1/users/',
-			query: {
-				skip, limit
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Create User
+   * Create new user.
+   * @returns UserPublic Successful Response
+   * @throws ApiError
+   */
+  public static createUser(
+    data: TDataCreateUser,
+  ): CancelablePromise<UserPublic> {
+    const { requestBody } = data
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/users/",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Create User
-	 * Create new user.
-	 * @returns UserPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static createUser(data: TDataCreateUser): CancelablePromise<UserPublic> {
-		const {
-requestBody,
-} = data;
-		return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/users/',
-			body: requestBody,
-			mediaType: 'application/json',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Read User Me
+   * Get current user.
+   * @returns UserPublic Successful Response
+   * @throws ApiError
+   */
+  public static readUserMe(): CancelablePromise<UserPublic> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/users/me",
+    })
+  }
 
-	/**
-	 * Read User Me
-	 * Get current user.
-	 * @returns UserPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static readUserMe(): CancelablePromise<UserPublic> {
-				return __request(OpenAPI, {
-			method: 'GET',
-			url: '/api/v1/users/me',
-		});
-	}
+  /**
+   * Delete User Me
+   * Delete own user.
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static deleteUserMe(): CancelablePromise<Message> {
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/api/v1/users/me",
+    })
+  }
 
-	/**
-	 * Delete User Me
-	 * Delete own user.
-	 * @returns Message Successful Response
-	 * @throws ApiError
-	 */
-	public static deleteUserMe(): CancelablePromise<Message> {
-				return __request(OpenAPI, {
-			method: 'DELETE',
-			url: '/api/v1/users/me',
-		});
-	}
+  /**
+   * Update User Me
+   * Update own user.
+   * @returns UserPublic Successful Response
+   * @throws ApiError
+   */
+  public static updateUserMe(
+    data: TDataUpdateUserMe,
+  ): CancelablePromise<UserPublic> {
+    const { requestBody } = data
+    return __request(OpenAPI, {
+      method: "PATCH",
+      url: "/api/v1/users/me",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Update User Me
-	 * Update own user.
-	 * @returns UserPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static updateUserMe(data: TDataUpdateUserMe): CancelablePromise<UserPublic> {
-		const {
-requestBody,
-} = data;
-		return __request(OpenAPI, {
-			method: 'PATCH',
-			url: '/api/v1/users/me',
-			body: requestBody,
-			mediaType: 'application/json',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Update Password Me
+   * Update own password.
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static updatePasswordMe(
+    data: TDataUpdatePasswordMe,
+  ): CancelablePromise<Message> {
+    const { requestBody } = data
+    return __request(OpenAPI, {
+      method: "PATCH",
+      url: "/api/v1/users/me/password",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Update Password Me
-	 * Update own password.
-	 * @returns Message Successful Response
-	 * @throws ApiError
-	 */
-	public static updatePasswordMe(data: TDataUpdatePasswordMe): CancelablePromise<Message> {
-		const {
-requestBody,
-} = data;
-		return __request(OpenAPI, {
-			method: 'PATCH',
-			url: '/api/v1/users/me/password',
-			body: requestBody,
-			mediaType: 'application/json',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Register User
+   * Create new user without the need to be logged in.
+   * @returns UserPublic Successful Response
+   * @throws ApiError
+   */
+  public static registerUser(
+    data: TDataRegisterUser,
+  ): CancelablePromise<UserPublic> {
+    const { requestBody } = data
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/users/signup",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Register User
-	 * Create new user without the need to be logged in.
-	 * @returns UserPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static registerUser(data: TDataRegisterUser): CancelablePromise<UserPublic> {
-		const {
-requestBody,
-} = data;
-		return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/users/signup',
-			body: requestBody,
-			mediaType: 'application/json',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Read User By Id
+   * Get a specific user by id.
+   * @returns UserPublic Successful Response
+   * @throws ApiError
+   */
+  public static readUserById(
+    data: TDataReadUserById,
+  ): CancelablePromise<UserPublic> {
+    const { userId } = data
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/users/{user_id}",
+      path: {
+        user_id: userId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Read User By Id
-	 * Get a specific user by id.
-	 * @returns UserPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static readUserById(data: TDataReadUserById): CancelablePromise<UserPublic> {
-		const {
-userId,
-} = data;
-		return __request(OpenAPI, {
-			method: 'GET',
-			url: '/api/v1/users/{user_id}',
-			path: {
-				user_id: userId
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Update User
+   * Update a user.
+   * @returns UserPublic Successful Response
+   * @throws ApiError
+   */
+  public static updateUser(
+    data: TDataUpdateUser,
+  ): CancelablePromise<UserPublic> {
+    const { requestBody, userId } = data
+    return __request(OpenAPI, {
+      method: "PATCH",
+      url: "/api/v1/users/{user_id}",
+      path: {
+        user_id: userId,
+      },
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Update User
-	 * Update a user.
-	 * @returns UserPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static updateUser(data: TDataUpdateUser): CancelablePromise<UserPublic> {
-		const {
-requestBody,
-userId,
-} = data;
-		return __request(OpenAPI, {
-			method: 'PATCH',
-			url: '/api/v1/users/{user_id}',
-			path: {
-				user_id: userId
-			},
-			body: requestBody,
-			mediaType: 'application/json',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
-
-	/**
-	 * Delete User
-	 * Delete a user.
-	 * @returns Message Successful Response
-	 * @throws ApiError
-	 */
-	public static deleteUser(data: TDataDeleteUser): CancelablePromise<Message> {
-		const {
-userId,
-} = data;
-		return __request(OpenAPI, {
-			method: 'DELETE',
-			url: '/api/v1/users/{user_id}',
-			path: {
-				user_id: userId
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
-
+  /**
+   * Delete User
+   * Delete a user.
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static deleteUser(data: TDataDeleteUser): CancelablePromise<Message> {
+    const { userId } = data
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/api/v1/users/{user_id}",
+      path: {
+        user_id: userId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 }
 
 export type TDataTestEmail = {
-                emailTo: string
-                
-            }
+  emailTo: string
+}
 
 export class UtilsService {
-
-	/**
-	 * Test Email
-	 * Test emails.
-	 * @returns Message Successful Response
-	 * @throws ApiError
-	 */
-	public static testEmail(data: TDataTestEmail): CancelablePromise<Message> {
-		const {
-emailTo,
-} = data;
-		return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/utils/test-email/',
-			query: {
-				email_to: emailTo
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
-
+  /**
+   * Test Email
+   * Test emails.
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static testEmail(data: TDataTestEmail): CancelablePromise<Message> {
+    const { emailTo } = data
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/utils/test-email/",
+      query: {
+        email_to: emailTo,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 }
 
 export type TDataReadItems = {
-                limit?: number
-skip?: number
-                
-            }
+  limit?: number
+  skip?: number
+}
 export type TDataCreateItem = {
-                requestBody: ItemCreate
-                
-            }
+  requestBody: ItemCreate
+}
 export type TDataReadItem = {
-                id: number
-                
-            }
+  id: number
+}
 export type TDataUpdateItem = {
-                id: number
-requestBody: ItemUpdate
-                
-            }
+  id: number
+  requestBody: ItemUpdate
+}
 export type TDataDeleteItem = {
-                id: number
-                
-            }
+  id: number
+}
 
 export class ItemsService {
+  /**
+   * Read Items
+   * Retrieve items.
+   * @returns ItemsPublic Successful Response
+   * @throws ApiError
+   */
+  public static readItems(
+    data: TDataReadItems = {},
+  ): CancelablePromise<ItemsPublic> {
+    const { limit = 100, skip = 0 } = data
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/items/",
+      query: {
+        skip,
+        limit,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Read Items
-	 * Retrieve items.
-	 * @returns ItemsPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static readItems(data: TDataReadItems = {}): CancelablePromise<ItemsPublic> {
-		const {
-limit = 100,
-skip = 0,
-} = data;
-		return __request(OpenAPI, {
-			method: 'GET',
-			url: '/api/v1/items/',
-			query: {
-				skip, limit
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Create Item
+   * Create new item.
+   * @returns ItemPublic Successful Response
+   * @throws ApiError
+   */
+  public static createItem(
+    data: TDataCreateItem,
+  ): CancelablePromise<ItemPublic> {
+    const { requestBody } = data
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/items/",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Create Item
-	 * Create new item.
-	 * @returns ItemPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static createItem(data: TDataCreateItem): CancelablePromise<ItemPublic> {
-		const {
-requestBody,
-} = data;
-		return __request(OpenAPI, {
-			method: 'POST',
-			url: '/api/v1/items/',
-			body: requestBody,
-			mediaType: 'application/json',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Read Item
+   * Get item by ID.
+   * @returns ItemPublic Successful Response
+   * @throws ApiError
+   */
+  public static readItem(data: TDataReadItem): CancelablePromise<ItemPublic> {
+    const { id } = data
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/items/{id}",
+      path: {
+        id,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Read Item
-	 * Get item by ID.
-	 * @returns ItemPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static readItem(data: TDataReadItem): CancelablePromise<ItemPublic> {
-		const {
-id,
-} = data;
-		return __request(OpenAPI, {
-			method: 'GET',
-			url: '/api/v1/items/{id}',
-			path: {
-				id
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
+  /**
+   * Update Item
+   * Update an item.
+   * @returns ItemPublic Successful Response
+   * @throws ApiError
+   */
+  public static updateItem(
+    data: TDataUpdateItem,
+  ): CancelablePromise<ItemPublic> {
+    const { id, requestBody } = data
+    return __request(OpenAPI, {
+      method: "PUT",
+      url: "/api/v1/items/{id}",
+      path: {
+        id,
+      },
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 
-	/**
-	 * Update Item
-	 * Update an item.
-	 * @returns ItemPublic Successful Response
-	 * @throws ApiError
-	 */
-	public static updateItem(data: TDataUpdateItem): CancelablePromise<ItemPublic> {
-		const {
-id,
-requestBody,
-} = data;
-		return __request(OpenAPI, {
-			method: 'PUT',
-			url: '/api/v1/items/{id}',
-			path: {
-				id
-			},
-			body: requestBody,
-			mediaType: 'application/json',
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
-
-	/**
-	 * Delete Item
-	 * Delete an item.
-	 * @returns Message Successful Response
-	 * @throws ApiError
-	 */
-	public static deleteItem(data: TDataDeleteItem): CancelablePromise<Message> {
-		const {
-id,
-} = data;
-		return __request(OpenAPI, {
-			method: 'DELETE',
-			url: '/api/v1/items/{id}',
-			path: {
-				id
-			},
-			errors: {
-				422: `Validation Error`,
-			},
-		});
-	}
-
+  /**
+   * Delete Item
+   * Delete an item.
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static deleteItem(data: TDataDeleteItem): CancelablePromise<Message> {
+    const { id } = data
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/api/v1/items/{id}",
+      path: {
+        id,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    })
+  }
 }


### PR DESCRIPTION
Since Hey API's openapi-ts CLI `--format` flag doesn't work (and is completely removed in newer versions), "manually" run biomi to correctly format the auto-generated code.

Note that at times the default formatting is completely broken (see `schemas.ts` as an example), and at times it's inconsistent (see  `OpenAPI.ts` as an example).
