### PR TITLE
🔧 Reuse database url from config in alembic setup

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -19,6 +19,7 @@ fileConfig(config.config_file_name)
 # target_metadata = None
 
 from app.models import SQLModel  # noqa
+from app.core.config import settings # noqa
 
 target_metadata = SQLModel.metadata
 
@@ -29,12 +30,7 @@ target_metadata = SQLModel.metadata
 
 
 def get_url():
-    user = os.getenv("POSTGRES_USER", "postgres")
-    password = os.getenv("POSTGRES_PASSWORD", "")
-    server = os.getenv("POSTGRES_SERVER", "db")
-    port = os.getenv("POSTGRES_PORT", "5432")
-    db = os.getenv("POSTGRES_DB", "app")
-    return f"postgresql+psycopg://{user}:{password}@{server}:{port}/{db}"
+    return str(settings.SQLALCHEMY_DATABASE_URI)
 
 
 def run_migrations_offline():

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -51,7 +51,7 @@ class Settings(BaseSettings):
     POSTGRES_SERVER: str
     POSTGRES_PORT: int = 5432
     POSTGRES_USER: str
-    POSTGRES_PASSWORD: str
+    POSTGRES_PASSWORD: str = ""
     POSTGRES_DB: str = ""
 
     @computed_field  # type: ignore[misc]


### PR DESCRIPTION
This PR changes alembic's `env` file to reuse database settings defined in `app.core.config` 😊

I've also taken the opportunity to allow having an empty `POSTGRES_PASSWORD`, when I develop locally I use https://postgresapp.com/ which creates a db without a password by default 😊