### PR TITLE
✨ Add mailcatcher configuration

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -62,6 +62,17 @@ services:
         INSTALL_DEV: ${INSTALL_DEV-true}
     # command: sleep infinity  # Infinite loop to keep container alive doing nothing
     command: /start-reload.sh
+    environment:
+      SMTP_HOST: "mailcatcher"
+      SMTP_PORT: "1025"
+      SMTP_TLS: "false"
+      EMAILS_FROM_EMAIL: "noreply@example.com"
+
+  mailcatcher:
+    image: schickling/mailcatcher
+    ports:
+      - "1080:1080"
+      - "1025:1025"
 
   frontend:
     restart: "no"


### PR DESCRIPTION
This PR adds mailcather when running docker compose for development. This will allow developers to see the emails that are being sent from the application
