### PR TITLE
Replace deprecated utcnow() with now(timezone.utc) in utils module

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -98,7 +98,7 @@ def generate_new_account_email(
 
 def generate_password_reset_token(email: str) -> str:
     delta = timedelta(hours=settings.EMAIL_RESET_TOKEN_EXPIRE_HOURS)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     expires = now + delta
     exp = expires.timestamp()
     encoded_jwt = jwt.encode(


### PR DESCRIPTION
This pull request addresses the deprecation of the datetime.utcnow() function by replacing it with datetime.now(timezone.utc) in the utils module.

Before
```
from datetime import datetime
datetime.utcnow()
```
After
```
from datetime import datetime, timezone
datetime.now(timezone.utc)
```

Source: https://docs-python-org.translate.goog/3/library/datetime.html?_x_tr_sl=en&_x_tr_tl=es&_x_tr_hl=es&_x_tr_pto=sc#datetime.datetime.utcnow