### PR TITLE
🚨 Fix Docker build warning

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 0, "build-stage", based on Node.js, to build and compile the frontend
-FROM node:20 as build-stage
+FROM node:20 AS build-stage
 
 WORKDIR /app
 


### PR DESCRIPTION
Fix warning in docker build...

```
 => [frontend internal] load build definition from Dockerfile                                                                                                                                          0.1s
 => => transferring dockerfile: 566B                                                                                                                                                                   0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)                                                                                                                         0.1s
```